### PR TITLE
Add S3 prefix filtering support in DailyCleanupHandler

### DIFF
--- a/DailyCleanupFunction/src/main/java/msjackiebrown/helpers/S3ClientHelper.java
+++ b/DailyCleanupFunction/src/main/java/msjackiebrown/helpers/S3ClientHelper.java
@@ -19,13 +19,21 @@ public class S3ClientHelper {
         this.s3Client = s3Client;
     }
 
-    public List<S3Object> listObjects(String bucketName) {
-        ListObjectsV2Request listObjectsRequest = ListObjectsV2Request.builder()
-                .bucket(bucketName)
-                .build();
+    public List<S3Object> listObjects(String bucketName, String prefix) {
+        ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
+                .bucket(bucketName);
+                
+        if (prefix != null && !prefix.isEmpty()) {
+            requestBuilder.prefix(prefix);
+        }
 
-        ListObjectsV2Response listObjectsResponse = s3Client.listObjectsV2(listObjectsRequest);
+        ListObjectsV2Response listObjectsResponse = s3Client.listObjectsV2(requestBuilder.build());
         return listObjectsResponse.contents();
+    }
+
+    // Overloaded method for backward compatibility
+    public List<S3Object> listObjects(String bucketName) {
+        return listObjects(bucketName, null);
     }
 
     public void deleteObject(String bucketName, String key) {

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ java-daily-cleanup-job/
 - `SNS_TOPIC_ARN`: ARN of SNS topic for notifications
 - `DRY_RUN`: Set to "true" to enable dry-run mode (default: "false")
 - `FILE_TYPES`: Comma-separated list of file extensions to clean up (e.g., ".log,.tmp,.bak"). If not set, all files are processed
+- `PREFIXES`: Comma-separated list of S3 prefixes/folders to clean up (e.g., "logs/,temp/"). If not set, all folders are processed
 
 ## Configuration Examples
 
@@ -87,6 +88,37 @@ FILE_TYPES=.log
 BUCKET_NAME=my-bucket
 DAYS=7
 FILE_TYPES=.tmp,.bak
+```
+
+### Clean up log files in specific folders:
+```sh
+BUCKET_NAME=my-bucket
+DAYS=30
+PREFIXES=logs/system/,logs/application/
+FILE_TYPES=.log
+```
+
+### Clean up temporary files in staging area:
+```sh
+BUCKET_NAME=my-bucket
+DAYS=1
+PREFIXES=temp/staging/
+FILE_TYPES=.tmp
+```
+
+### Clean up all files in archive folders older than 90 days:
+```sh
+BUCKET_NAME=my-bucket
+DAYS=90
+PREFIXES=archive/2023/,archive/2022/
+```
+
+### Preview deletion of log files (dry run):
+```sh
+BUCKET_NAME=my-bucket
+DAYS=30
+FILE_TYPES=.log
+DRY_RUN=true
 ```
 
 ## Building

--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,7 @@ Globals:
         SNS_TOPIC_ARN: !Ref DailyCleanupSNSTopic
         DRY_RUN: "false"  # Add this line - set to "true" for dry-run mode
         FILE_TYPES: ".log,.tmp,.bak"  # Add this line
+        PREFIXES: "logs/,temp/,backup/"  # Add this line
 
 Resources:
   DailyCleanupSNSTopic:


### PR DESCRIPTION
Issue #3: Introduce prefix filtering for file deletion in DailyCleanupHandler and update S3ClientHelper to handle prefixes. Update README.md with configuration examples for using prefixes.